### PR TITLE
合計金額を表示できるようにした

### DIFF
--- a/app/controllers/payments_controller.rb
+++ b/app/controllers/payments_controller.rb
@@ -1,6 +1,6 @@
 class PaymentsController < ApplicationController
   def index
-    @payments = Payment.all
+    @payments = Payment.all.order(:paid_at)
   end
 
   def new

--- a/app/controllers/payments_controller.rb
+++ b/app/controllers/payments_controller.rb
@@ -15,6 +15,9 @@ class PaymentsController < ApplicationController
     @payment = Payment.new(payment_params)
 
     if @payment.save
+      # TODO: 長いのでメソッドに切り分けるなりしたい
+      @payment.broadcast_replace_to "total_amount", target: "total_amount", partial: "payments/total_amount", locals: { total_amount: Payment.total_amount(Time.current.beginning_of_month..Time.current.end_of_month) }
+
       flash.now.notice = "支払を作成しました"
     else
       render :new, status: :unprocessable_entity
@@ -25,6 +28,8 @@ class PaymentsController < ApplicationController
     @payment = Payment.find(params[:id])
 
     if @payment.update(payment_params)
+      # TODO: 長いのでメソッドに切り分けるなりしたい
+      @payment.broadcast_replace_to "total_amount", target: "total_amount", partial: "payments/total_amount", locals: { total_amount: Payment.total_amount(Time.current.beginning_of_month..Time.current.end_of_month) }
       flash.now.notice = "支払を更新しました"
     else
       render :edit, status: :unprocessable_entity

--- a/app/controllers/payments_controller.rb
+++ b/app/controllers/payments_controller.rb
@@ -40,6 +40,7 @@ class PaymentsController < ApplicationController
     @payment = Payment.find(params[:id])
 
     @payment.destroy!
+    @payment.broadcast_replace_to "total_amount", target: "total_amount", partial: "payments/total_amount", locals: { total_amount: Payment.total_amount(Time.current.beginning_of_month..Time.current.end_of_month) }
     flash.now.notice = "支払を削除しました"
   end
 

--- a/app/models/payment.rb
+++ b/app/models/payment.rb
@@ -5,4 +5,6 @@ class Payment < ApplicationRecord
   validates :name, presence: true
 
   enum :kind, %i[half individual]
+
+  broadcasts_to -> (payment) { "payments" }
 end

--- a/app/models/payment.rb
+++ b/app/models/payment.rb
@@ -7,4 +7,10 @@ class Payment < ApplicationRecord
   enum :kind, %i[half individual]
 
   broadcasts_to -> (payment) { "payments" }
+
+  def self.total_amount(term)
+    raise ArgumentError, "" unless term.is_a?(Range)
+
+    Payment.where(paid_at: term).sum(:amount)
+  end
 end

--- a/app/views/payments/_total_amount.html.erb
+++ b/app/views/payments/_total_amount.html.erb
@@ -1,0 +1,11 @@
+<%= turbo_frame_tag "total_amount" do %>
+  <div>
+    <% #TODO: 後で、ユーザーに紐づく total_amount を表示する %>
+    <%= total_amount || 0 %>
+  </div>
+
+  <div>
+    <% #TODO: 後で、ユーザーに紐づく total_amount を表示する %>
+    <%= total_amount || 0 %>
+  </div>
+<% end %>

--- a/app/views/payments/create.turbo_stream.erb
+++ b/app/views/payments/create.turbo_stream.erb
@@ -1,5 +1,3 @@
-<%= turbo_stream.prepend "payments", @payment %>
-
 <%= turbo_stream.update Payment.new, "" %>
 
 <%= turbo_stream.update "flash", partial: "flash" %>

--- a/app/views/payments/destroy.turbo_stream.erb
+++ b/app/views/payments/destroy.turbo_stream.erb
@@ -1,2 +1,1 @@
-<%= turbo_stream.remove @payment %>
 <%= turbo_stream.update "flash", partial: "flash" %>

--- a/app/views/payments/index.html.erb
+++ b/app/views/payments/index.html.erb
@@ -1,4 +1,7 @@
 <%= turbo_stream_from "payments" %>
+<%= turbo_stream_from "total_amount" %>
+
+<%= render "total_amount", total_amount: Payment.total_amount(Time.current.beginning_of_month..Time.current.end_of_month)  %>
 
 <div class="flex w-11/12 flex-col justify-center m-auto">
   <div class="grid grid-cols-6 mb-5">

--- a/app/views/payments/index.html.erb
+++ b/app/views/payments/index.html.erb
@@ -1,3 +1,5 @@
+<%= turbo_stream_from "payments" %>
+
 <div class="flex w-11/12 flex-col justify-center m-auto">
   <div class="grid grid-cols-6 mb-5">
     <h1 class="mb-4 text-3xl font-black col-start-1 col-end-3"><%= t("activerecord.models.payment") %></h1>

--- a/app/views/payments/update.turbo_stream.erb
+++ b/app/views/payments/update.turbo_stream.erb
@@ -1,2 +1,1 @@
-<%= turbo_stream.replace @payment %>
 <%= turbo_stream.update "flash", partial: "flash" %>

--- a/config/application.rb
+++ b/config/application.rb
@@ -3,7 +3,7 @@ require_relative "boot"
 require "rails"
 # Pick the frameworks you want:
 require "active_model/railtie"
-# require "active_job/railtie"
+require "active_job/railtie"
 require "active_record/railtie"
 # require "active_storage/engine"
 require "action_controller/railtie"


### PR DESCRIPTION
## 概要

ref: #22 

仮の合計金額を表示できるようにした。

## やったこと

- [x] turbo_stream を使って、支払を登録・編集・削除したら合計金額をリアルタイムで更新するようにした

## やらなかったこと

- デザインを当てる
- 合計金額表示機能はグループの1ヶ月の合計金額を表示できるようにしたかったが、グループ機能がないため仮の合計金額表示とした

## 動作確認方法
## 参考
