### PR TITLE
自作 FactoryBot を導入

### DIFF
--- a/spec/factories/payments.rb
+++ b/spec/factories/payments.rb
@@ -1,0 +1,21 @@
+Factory.define do
+  factory :payment do
+    amount { 1000 }
+    paid_at { Time.current }
+    kind { Payment.kinds.keys.sample }
+    name { "外食" }
+    note { "#{Time.current.strftime('%Y/%m')}にレストランで食事した。"}
+
+    association do
+
+    end
+
+    sequence do |i|
+      amount { "#{i}000".to_i }
+      paid_at { Time.current + i.day }
+      kind { Payment.kinds.keys.sample }
+      name { "外食_#{i}" }
+      note { "#{Time.current.strftime('%Y/%m')}にレストラン#{i}で食事した。"}
+    end
+  end
+end

--- a/spec/models/monthly_expense_spec.rb
+++ b/spec/models/monthly_expense_spec.rb
@@ -13,6 +13,8 @@ RSpec.describe MonthlyExpense, type: :model do
   end
 
   describe "#payments" do
+    Factory.create(:payment, amount: 1000, paid_at: Time.current)
+    Factory.create_list(:payment, 10)
   end
 
   describe "#next_year_and_month_hash" do


### PR DESCRIPTION
ref: https://github.com/koheitakahashi/tatsumaki/issues/41

# メモ

- FactoryBot 的な機能を自分で作りたい
- lib/factory のディレクトリを作ってそこに置くイメージ
- 定義方法は `spec/factories/payments.rb` のイメージ
  - FactoryBot で association のオブジェクトまで生成してしまうと、複数の Factory のファイルを見る必要があって、association の全体像を置いにくいという問題がある
    - これを解決したいが、解決方法がまだ定まっていない
  - 一旦は、関連するオブジェクトを生成することが強調されている状態にとどめておくとして、`association do ` のように関連付けを定義することを考えている

- ユーザーとグループ機能ができたら、これに取り組む